### PR TITLE
Feature/q UI z 14

### DIFF
--- a/.github/workflows/backend_unittests.yml
+++ b/.github/workflows/backend_unittests.yml
@@ -34,7 +34,8 @@ jobs:
 
     - name: Set up application-test.properties
       run: |
-        echo "${{ secrets.APPLICATION_TEST }}" > server/src/test/resources/application-test.properties
+        cd server/src/main/resources
+        echo "${{ secrets.APPLICATION_TEST }}" > application-test.properties
 
     - name: Run tests
       run: |

--- a/.github/workflows/backend_unittests.yml
+++ b/.github/workflows/backend_unittests.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'pull_request' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Set up JDK 22
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options

--- a/.github/workflows/backend_unittests.yml
+++ b/.github/workflows/backend_unittests.yml
@@ -1,17 +1,12 @@
 name: Run Unit Tests
 
 on:
-    push:
-      branches: 
-        - '*'         # matches every branch that doesn't contain a '/'
-        - '*/*'       # matches every branch containing a single '/'
-        - '**'        # matches every branch
-    pull_request:
-      branches:  "main"
+  pull_request:
+    branches:
+      - '**'  # Matches all branches, or specify specific branches if needed
 
 jobs:
   build:
-    if: ${{ github.event_name == 'pull_request' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +16,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'temurin' # See 'Supported distributions' for available options
+        distribution: 'temurin'  # See 'Supported distributions' for available options
         java-version: '17'
 
     - name: Cache Maven packages
@@ -36,11 +31,10 @@ jobs:
       run: |
         cd server
         mvn install -DskipTests
-    
+
     - name: Set up application-test.properties
       run: |
-        cd server/src/main/resources
-        echo "${{ secrets.APPLICATION_TEST }}" > application-test.properties
+        echo "${{ secrets.APPLICATION_TEST }}" > server/src/test/resources/application-test.properties
 
     - name: Run tests
       run: |

--- a/db_scripts/user_security_setup.sql
+++ b/db_scripts/user_security_setup.sql
@@ -20,6 +20,7 @@ create table `users` (
     `security_id` int DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `FK_SECURITY_idx` (`security_id`),
+    UNIQUE KEY `unique_email` (`email`),
     CONSTRAINT `FK_SECURITY` FOREIGN KEY (`security_id`) REFERENCES `security` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB auto_increment=1 default charset=latin1;
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -88,6 +88,11 @@
 			<version>4.0.1</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,9 +14,9 @@
 	<name>study-webapp</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>22</java.version>
-		<maven.compiler.source>22</maven.compiler.source>
-		<maven.compiler.target>22</maven.compiler.target>
+		<java.version>17</java.version>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,9 +14,9 @@
 	<name>study-webapp</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
-		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<java.version>22</java.version>
+		<maven.compiler.source>22</maven.compiler.source>
+		<maven.compiler.target>22</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +67,27 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>4.0.1</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -83,6 +104,15 @@
 						<include>StudyWebappApplicationTest.java</include>
 						<!-- Add other test classes or patterns as needed -->
 					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>22</source>
+					<target>22</target>
+					<compilerArgs>--enable-preview</compilerArgs>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/server/src/main/java/com/example/server/dao/UserDAO.java
+++ b/server/src/main/java/com/example/server/dao/UserDAO.java
@@ -15,4 +15,5 @@ public interface UserDAO {
     User updateUser(User user, int id) throws Exception;
     void deleteUser(int id);
     void createSecurity(User user, Security security);
+    User login(String username, String password);
 }

--- a/server/src/main/java/com/example/server/dao/UserDAOImpl.java
+++ b/server/src/main/java/com/example/server/dao/UserDAOImpl.java
@@ -4,6 +4,7 @@ import com.example.server.entities.Security;
 import com.example.server.entities.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.TypedQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,15 @@ public class UserDAOImpl implements UserDAO {
         user.setSecurity(security);
         security.setUser(user);
         em.merge(user);
+    }
+
+    @Override
+    public User login(String email, String password) {
+        // Uses parameters so should be safe from SQL injection
+        String preparedQueryString = "from User where email = :email and password = :password";
+        TypedQuery<User> preparedQuery = em.createQuery(preparedQueryString, User.class)
+                .setParameter("email", email).setParameter("password", password);
+        return preparedQuery.getSingleResult();
     }
 
     @Override

--- a/server/src/main/java/com/example/server/routes/AuthRoutes.java
+++ b/server/src/main/java/com/example/server/routes/AuthRoutes.java
@@ -1,0 +1,54 @@
+package com.example.server.routes;
+
+import com.example.server.entities.User;
+import com.example.server.services.JwtService;
+import com.example.server.services.JwtUser;
+import com.example.server.services.route_services.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.servlet.http.Cookie;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping
+public class AuthRoutes {
+    private final HttpServletResponse httpServletResponse;
+    private AuthService authService;
+    private JwtService jwtService;
+
+    @Value("${jwt.access.name}")
+    private String accessTokenName;
+
+    @Autowired
+    public AuthRoutes(AuthService authService, JwtService jwtService, HttpServletResponse httpServletResponse) {
+        this.authService = authService;
+        this.jwtService = jwtService;
+        this.httpServletResponse = httpServletResponse;
+    }
+
+    @PostMapping("${routes.login}")
+    public String login(@RequestBody Map<String, String> loginData) {
+        User result = authService.login(loginData.get("email"), loginData.get("password"));
+
+        if (result != null) {
+            JwtUser tempUser = new JwtUser(result.getEmail());
+            Cookie cookie = new Cookie(accessTokenName, jwtService.generateToken(tempUser));
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
+            cookie.setPath("/");
+            cookie.setMaxAge((int) jwtService.getAccessExpiry() / 1000 );
+
+            httpServletResponse.addCookie(cookie);
+            return "Check success?";
+        } else { return "FAILURE"; }
+    }
+
+    @GetMapping("${routes.login}")
+    public String TestSecurity() {
+        return "FAILED SHOULD NOT EXECUTE WITHOUT TOKEN";
+    }
+}

--- a/server/src/main/java/com/example/server/routes/UserRoutes.java
+++ b/server/src/main/java/com/example/server/routes/UserRoutes.java
@@ -2,7 +2,7 @@ package com.example.server.routes;
 
 import com.example.server.entities.Security;
 import com.example.server.entities.User;
-import com.example.server.services.UserService;
+import com.example.server.services.route_services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/server/src/main/java/com/example/server/security/JwtRequestFilter.java
+++ b/server/src/main/java/com/example/server/security/JwtRequestFilter.java
@@ -1,0 +1,79 @@
+package com.example.server.security;
+
+import com.example.server.services.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    JwtService jwtService;
+
+    @Autowired
+    private HandlerExceptionResolver handlerExceptionResolver;
+
+    @Value("${jwt.access.name}")
+    private String accessTokenName;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        RequestMatcher ignoredPath = new AntPathRequestMatcher("/api/auth");
+        if (ignoredPath.matches(request) && request.getMethod().equals("POST")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Cookie[] cookies = request.getCookies();
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(accessTokenName)) {
+                try {
+                    if (jwtService.validate(cookie.getValue())) {
+                        String user = jwtService.getUserFromToken(cookie.getValue());
+
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                user, null, new ArrayList<>());
+
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
+                } catch (Exception e) {
+                    handlerExceptionResolver.resolveException(request, response, null, e);
+                    return;
+                }
+            }
+        }
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+    @Bean
+    public FilterRegistrationBean registration(JwtRequestFilter filter) {
+        FilterRegistrationBean registration = new FilterRegistrationBean(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}
+

--- a/server/src/main/java/com/example/server/security/UserSecurityConfig.java
+++ b/server/src/main/java/com/example/server/security/UserSecurityConfig.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration
 @EnableWebSecurity

--- a/server/src/main/java/com/example/server/security/UserSecurityConfig.java
+++ b/server/src/main/java/com/example/server/security/UserSecurityConfig.java
@@ -1,24 +1,36 @@
 package com.example.server.security;
 
+import com.example.server.services.JwtService;
+import io.jsonwebtoken.Jwt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
-// Basic, temporary security configuration that allows for all requests to be authorized.
 @Configuration
 @EnableWebSecurity
 public class UserSecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(configurer -> configurer
-                .anyRequest().permitAll()
-        );
-        http.httpBasic(httpBasic -> httpBasic.disable());
-        http.csrf(csrf -> csrf.disable());
+    @Autowired
+    private JwtRequestFilter jwtRequestFilter;
 
+    @Bean
+    public SecurityFilterChain jwtChain(HttpSecurity http) throws Exception {
+
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorize -> authorize.requestMatchers("/auth").permitAll()
+                    .anyRequest().authenticated())
+            .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }
+

--- a/server/src/main/java/com/example/server/services/JwtService.java
+++ b/server/src/main/java/com/example/server/services/JwtService.java
@@ -1,0 +1,29 @@
+package com.example.server.services;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface JwtService {
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver);
+
+    public Claims getAllClaimsFromToken(String token);
+
+    public long getAccessExpiry();
+
+    public String generateToken(JwtUser user);
+
+    public Date getExpirationDate(String token);
+
+    public String getUserFromToken(String token);
+
+    public Boolean validate(String token);
+}

--- a/server/src/main/java/com/example/server/services/JwtServiceImpl.java
+++ b/server/src/main/java/com/example/server/services/JwtServiceImpl.java
@@ -1,0 +1,72 @@
+package com.example.server.services;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtServiceImpl implements JwtService {
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiry}")
+    private long accessExpiry;
+
+    public long getAccessExpiry() { return accessExpiry; }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public Claims getAllClaimsFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(getSignInKey()).build().parseClaimsJws(token).getBody();
+    }
+
+    public String generateToken(JwtUser user) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put(user.test, "test");
+        return Jwts.builder().setClaims(claims).setSubject(user.getEmail()).setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + accessExpiry))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS512).compact();
+    }
+
+    private Key getSignInKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public Date getExpirationDate(String token) {
+        return getClaimFromToken(token, Claims::getExpiration);
+    }
+
+    public String getUserFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    private Boolean isExpired(String token) {
+        final Date expiration = getExpirationDate(token);
+        return expiration.before(new Date());
+    }
+
+    public Boolean validate(String token) {
+        try {
+            if (!isExpired(token)) { return true; }
+        } catch (SignatureException e) {
+            System.out.println("Invalid JWT signature: " + e.getMessage());
+        } catch (Exception e) {
+            System.out.println("Invalid JWT token: " + e.getMessage());
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/com/example/server/services/JwtUser.java
+++ b/server/src/main/java/com/example/server/services/JwtUser.java
@@ -1,0 +1,12 @@
+package com.example.server.services;
+
+public class JwtUser {
+
+    private String email;
+    public String test;
+
+    public JwtUser(String email) { this.email = email;
+    test = "Test"; }
+
+    public String getEmail() { return email; }
+}

--- a/server/src/main/java/com/example/server/services/route_services/AuthService.java
+++ b/server/src/main/java/com/example/server/services/route_services/AuthService.java
@@ -1,0 +1,7 @@
+package com.example.server.services.route_services;
+
+import com.example.server.entities.User;
+
+public interface AuthService {
+    public User login(String email, String password);
+}

--- a/server/src/main/java/com/example/server/services/route_services/AuthServiceImpl.java
+++ b/server/src/main/java/com/example/server/services/route_services/AuthServiceImpl.java
@@ -1,0 +1,20 @@
+package com.example.server.services.route_services;
+
+import com.example.server.dao.UserDAO;
+import com.example.server.entities.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthServiceImpl implements AuthService{
+
+    private UserDAO userDAO;
+
+    @Autowired
+    public AuthServiceImpl(UserDAO userDAO) { this.userDAO = userDAO; }
+
+    @Override
+    public User login(String email, String password) {
+        return userDAO.login(email, password);
+    }
+}

--- a/server/src/main/java/com/example/server/services/route_services/UserService.java
+++ b/server/src/main/java/com/example/server/services/route_services/UserService.java
@@ -1,4 +1,4 @@
-package com.example.server.services;
+package com.example.server.services.route_services;
 
 import com.example.server.entities.Security;
 import com.example.server.entities.User;

--- a/server/src/main/java/com/example/server/services/route_services/UserServiceImpl.java
+++ b/server/src/main/java/com/example/server/services/route_services/UserServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.server.services;
+package com.example.server.services.route_services;
 
 import com.example.server.dao.UserDAO;
 import com.example.server.entities.Security;

--- a/server/src/main/resources/templates/template_application-test.properties
+++ b/server/src/main/resources/templates/template_application-test.properties
@@ -1,9 +1,21 @@
-spring.datasource.url=
-spring.datasource.username=
-spring.datasource.password=
-
-spring.jpa.hibernate.ddl-auto=
-
 # routes env variables
 routes.users=
-spring.mvc.servlet.path=
+routes.login=
+
+# JDBC properties
+spring.datasource.url=
+spring.datasource.driver-class-name=
+spring.datasource.username=
+spring.datasource.password=
+spring.jpa.database-platform=
+spring.jpa.hibernate.ddl-auto=
+
+resetKey.expiry.minutes=
+
+jwt.secret.key=
+jwt.access.expiry=
+jwt.access.name=
+
+server.servlet.session.cookie.same-site=
+
+spring.security.filter.order=

--- a/server/src/main/resources/templates/template_application.properties
+++ b/server/src/main/resources/templates/template_application.properties
@@ -2,6 +2,10 @@ spring.application.name=
 
 spring.mvc.servlet.path=
 
+# routes env variables
+routes.users=
+routes.login=
+
 # JDBC properties
 spring.datasource.url=
 spring.datasource.username=
@@ -11,5 +15,10 @@ spring.jpa.hibernate.ddl-auto=
 
 resetKey.expiry.minutes=
 
-# routes env variables
-routes.users=
+jwt.secret.key=
+jwt.access.expiry=
+jwt.access.name=
+
+server.servlet.session.cookie.same-site=
+
+spring.security.filter.order=

--- a/server/src/test/java/com/example/server/TestUtilFunctions.java
+++ b/server/src/test/java/com/example/server/TestUtilFunctions.java
@@ -1,0 +1,26 @@
+package com.example.server;
+
+import com.example.server.services.JwtService;
+import com.example.server.services.JwtUser;
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@Component
+public class TestUtilFunctions {
+    @Value("${jwt.access.name}")
+    private String accessTokenName;
+
+    @Autowired
+    private JwtService jwtService;
+
+    // Utility method to set JWT cookie
+    public Cookie getJwtCookie(String email) throws Exception {
+        return new Cookie(accessTokenName, jwtService.generateToken(new JwtUser(email)));
+    }
+}

--- a/server/src/test/java/com/example/server/UserRoutesTest.java
+++ b/server/src/test/java/com/example/server/UserRoutesTest.java
@@ -1,20 +1,22 @@
 package com.example.server;
 
 import com.example.server.entities.User;
-import com.example.server.routes.UserRoutes;
-import com.example.server.security.UserSecurityConfig;
 import com.example.server.services.route_services.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -23,9 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 // UserRouteTests exist to test the function of the UserRoutes rest controller. It exists to ensure that the date given
 // through the UserService is formatting in a consistent way.
-@WebMvcTest(UserRoutes.class)
-@ExtendWith(SpringExtension.class)
-@Import({UserSecurityConfig.class})
+@SpringBootTest
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
 public class UserRoutesTest {
         @Value("${routes.users}")
@@ -33,6 +34,9 @@ public class UserRoutesTest {
 
         @Autowired
         private MockMvc mockMvc;
+
+        @Autowired
+        private TestUtilFunctions utilFunctions;
 
         @MockBean
         private UserService service;
@@ -47,7 +51,8 @@ public class UserRoutesTest {
             when(service.findUserById(1)).thenReturn(returnUser);
 
             // Perform the GET request to /api/users/1 and verify the response
-            mockMvc.perform(get(endPoint + "/1"))
+            mockMvc.perform(get(endPoint + "/1")
+                            .cookie(utilFunctions.getJwtCookie("bjones@gmail.com")))
                     .andExpect(status().isOk()) // Check for HTTP 200 OK status
                     .andExpect(content().contentType("application/json")) // Optional: Verify content type
                     .andExpect(jsonPath("$.firstName").value("Bepis")) // Example: Verify response JSON content
@@ -64,7 +69,7 @@ public class UserRoutesTest {
             when(service.findAllUsers()).thenReturn(List.of(returnUsers));
 
             // Perform the GET request to /api/users and verify the response
-            mockMvc.perform(get(endPoint))
+            mockMvc.perform(get(endPoint).cookie(utilFunctions.getJwtCookie("bjones@gmail.com")))
                     .andExpect(status().isOk()) // Check for HTTP 200 OK status
                     .andExpect(content().contentType("application/json"))
                     .andExpect(jsonPath("$.length()").value(returnUsers.length))
@@ -83,6 +88,7 @@ public class UserRoutesTest {
             when(service.saveUser(provideUser)).thenReturn(provideUser);
 
             mockMvc.perform(post(endPoint)
+                            .cookie(utilFunctions.getJwtCookie("bjones@gmail.com"))
                             .accept("application/json")
                             .contentType("application/json")
                             .content(Obj.writeValueAsString(provideUser)))
@@ -94,7 +100,7 @@ public class UserRoutesTest {
 
         @Test
         public void deleteUser() throws Exception {
-            mockMvc.perform(delete(endPoint + "/1"))
+            mockMvc.perform(delete(endPoint + "/1").cookie(utilFunctions.getJwtCookie("bjones@gmail.com")))
                     .andExpect(status().isOk()); // Check for HTTP 200 OK status
         }
 
@@ -106,6 +112,7 @@ public class UserRoutesTest {
             when(service.updateUser(provideUser, 1)).thenReturn(provideUser);
 
             mockMvc.perform(put(endPoint + "/1")
+                            .cookie(utilFunctions.getJwtCookie("bjones@gmail.com"))
                             .accept("application/json")
                             .contentType("application/json")
                             .content(Obj.writeValueAsString(provideUser)))

--- a/server/src/test/java/com/example/server/UserRoutesTest.java
+++ b/server/src/test/java/com/example/server/UserRoutesTest.java
@@ -3,7 +3,7 @@ package com.example.server;
 import com.example.server.entities.User;
 import com.example.server.routes.UserRoutes;
 import com.example.server.security.UserSecurityConfig;
-import com.example.server.services.UserService;
+import com.example.server.services.route_services.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
# JWT SECURITY

JWT cookies will be required for any route that is not /api/auth. I will update the code so that /api/user POST method (creates a user) is accessible without a JWT token in the request. 

/api/auth is the login route, and providing correct values will result in a successful response that inserts a cookie with the jwt during the response. The cookie information is set via the application.properties file, i.e. the cookie name, secret key for encryption, and expiry time (in milliseconds).
